### PR TITLE
Allow newer version of paramiko to be installed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ bcrypt==3.1.7
 bsdiff4==1.1.9
 cffi==1.13.2
 cryptography==3.3.2
-paramiko==2.7.0
+paramiko>=2.7.0
 pycparser==2.19
 PyNaCl==1.3.0
 pyusb==1.0.2


### PR DESCRIPTION
This is according to the change in OpenSSH private key format. On newer systems, this is mandatory.

https://stackoverflow.com/a/60000004